### PR TITLE
Consistent paths

### DIFF
--- a/env-sample
+++ b/env-sample
@@ -1,0 +1,17 @@
+#
+# .env file
+# 
+# Fill in <blanks> file and name as `.env` in repo root
+#
+LOTUS_API=http://127.0.0.1:1234/rpc/v0
+LOTUS_TOKEN=<lotus API token>
+LOTUS_RETRIEVE=files
+
+DB_HOST=<hostname>
+DB_USER=<username>
+DB_PASS=<password>
+DB_NAME=<database name>
+
+TOKEN_SECRET=<put a random 32-character seed string here>
+TOKEN_EXPIRES_IN=7 days
+

--- a/src/services/lotus.spec.ts
+++ b/src/services/lotus.spec.ts
@@ -81,7 +81,8 @@ describe('services/lotus', () => {
     it(
       'returns a file',
       async () => {
-        const file = await retrieve(mock.cid, mock.miner, mock.retrieveWallet)
+        const outPath = `./test-result-${mock.cid}`
+        const file = await retrieve(mock.cid, mock.miner, mock.retrieveWallet, outPath)
 
         expect(file).toBeTruthy()
       },

--- a/src/services/lotus.ts
+++ b/src/services/lotus.ts
@@ -5,7 +5,7 @@ import * as intervalPromise from 'interval-promise'
 import { env } from '../config'
 import { logger } from './logger'
 
-const { api: apiUrl, token, retrievePath } = env.lotus
+const { api: apiUrl, token, _retrievePath } = env.lotus
 const retrieveTimeout = 30 * 60000 // 30 mins
 
 const interval = (intervalPromise as any) as typeof intervalPromise.default
@@ -131,8 +131,9 @@ export const getCIDAvailability = async (dataCid, minerID) => {
   return result
 }
 
-export const retrieve = async (dataCid: string, minerID: string, wallet: string) => {
-  let filePath: string
+// TODO: this no longer needs to return the filepath since we pass it in
+export const retrieve = async (dataCid: string, minerID: string, wallet: string, outFilePath: string) => {
+  logger.log(`retrieve:  dataCid:${dataCid}, minerID:'${minerID}', wallet:'${wallet}', outFilePath:'${outFilePath}'`)
 
   try {
     const queryOffer = await queryMinerOffer(dataCid, minerID)
@@ -150,14 +151,13 @@ export const retrieve = async (dataCid: string, minerID: string, wallet: string)
         Miner: queryOffer.Miner,
         MinerPeer: queryOffer.MinerPeer,
       }
-      filePath = `${retrievePath.replace(/\/$/, '')}/${dataCid}`
 
-      const retrieveResult = await getClientRetrieve(retrievalOffer, filePath)
+      const retrieveResult = await getClientRetrieve(retrievalOffer, outFilePath)
 
       logger.log('retrieve result: ', retrieveResult)
 
       if (retrieveResult.error) {
-        filePath = undefined
+        outFilePath = undefined
         throw new Error(JSON.stringify(retrieveResult.error))
       }
     }
@@ -165,5 +165,5 @@ export const retrieve = async (dataCid: string, minerID: string, wallet: string)
     logger.error('Error retrieving file\n', err)
   }
 
-  return filePath
+  return outFilePath
 }

--- a/src/services/send-chunk.ts
+++ b/src/services/send-chunk.ts
@@ -20,8 +20,16 @@ export const sendChunk = async (io: socketIO.Server | socketIO.Socket, message) 
 
     // retrieve file if it doesn't exist
     const filePath = path.join(env.rootDir, env.lotus.retrievePathLocal, entry.cidRequested)
+    logger.log(`Looking for ${entry.cidRequested} locally at '${filePath}'`)
+    logger.log(`  env.rootDir: '${env.rootDir}'`)
+    logger.log(`  env.lotus.retrievePathLocal: '${env.lotus.retrievePathLocal}'`)
     if (!fs.existsSync(filePath)) {
-      await lotus.retrieve(entry.cidRequested, entry.minerRequested, entry.walletAddress)
+      logger.log(
+        `Did not find ${entry.cidRequested} locally; performing storage miner retrieve from ${entry.minerRequested} instead`,
+      )
+      await lotus.retrieve(entry.cidRequested, entry.minerRequested, entry.walletAddress, filePath)
+    } else {
+      logger.log(`Found ${entry.cidRequested} locally; no storage miner retrieval needed`)
     }
 
     const tempFileChecksum = await sha256File(filePath)

--- a/src/services/send-cid-availability.ts
+++ b/src/services/send-cid-availability.ts
@@ -8,11 +8,7 @@ import * as lotus from './lotus'
 import { createToken } from './token'
 
 const messageType = 'cid_availability'
-// 0.00000003280361043
-// 0.00000101
-
-// 1010000000000
-const TEMPgasCostPerProxyRetrieval = new BigNumber('1010000000000')
+const minimunPriceForRetrievalPerGb = new BigNumber('10100000000000')
 const gasCostPerProxyRetrieval = new BigNumber('32803602238')
 
 export const sendCidAvailability = async (io: socketIO.Server | socketIO.Socket, message) => {
@@ -32,7 +28,10 @@ export const sendCidAvailability = async (io: socketIO.Server | socketIO.Socket,
       available: isAvailable,
       approxSize: data.result.Size,
 
-      price_attofil: priceAttofil.plus(gasCostPerProxyRetrieval).plus(TEMPgasCostPerProxyRetrieval).toString(),
+      price_attofil: priceAttofil
+        .plus(gasCostPerProxyRetrieval)
+        .plus(minimunPriceForRetrievalPerGb.times(10))
+        .toString(),
       payment_wallet: paymentWallet.result,
     }
 


### PR DESCRIPTION
@aistoc I created this pull request because I could not get the proxy-retrieval app working on the retrievalproxy server.  I was running into log errors like this:

```
2020-11-04T23:15:34.998Z [error]: Could not send chunk. [Error: ENOENT: no such file or directory, open '/home/ubuntu/proxy-retrieval/home/ubuntu/proxy-retrieval/files/bafk2bzacebhlhbcnhmvover42qq5bx773c522skieho6nhtbz7d2ow3f4sw24'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/home/ubuntu/proxy-retrieval/home/ubuntu/proxy-retrieval/files/bafk2bzacebhlhbcnhmvover42qq5bx773c522skieho6nhtbz7d2ow3f4sw24'
}
```

(Note the double `/home/ubuntu/proxy-retrieval`.

I didn't want to change env.rootPath, so I instead changed the .env file to this:

```
LOTUS_RETRIEVE=files
```

and then added an argument to lotus.retrieve to specify the outFilePath instead of letting that function compute it on its own.   I don't know if this was the right solution, but it does work now on the server.